### PR TITLE
Remove pin 13 for Mega as it's on Timer 0

### DIFF
--- a/config/known_16bit_timers.h
+++ b/config/known_16bit_timers.h
@@ -64,7 +64,6 @@
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
   #define TIMER1_A_PIN   11
   #define TIMER1_B_PIN   12
-  #define TIMER1_C_PIN   13
   #define TIMER3_A_PIN   5
   #define TIMER3_B_PIN   2
   #define TIMER3_C_PIN   3


### PR DESCRIPTION
Description
As far as I've been able to tell from the Arduino Mega documentation Pin 13 is on Timer zero and there is no TIMER1_C_PIN on the Mega even though it is a 16bit timer.

Steps To Reproduce Problem
See this blog post as secondary reference which also indicates that Pin 13 is not on timer 1
http://sobisource.com/arduino-mega-pwm-pin-and-frequency-timer-control/

Hardware & Software
Board Mega

Note: This incorrect pin 13 value is in both the [TimerOne](https://github.com/PaulStoffregen/TimerOne/pull/37) and [TimerThree](https://github.com/PaulStoffregen/TimerThree/pull/9) Config files I have opened PR for those to be fixed too